### PR TITLE
c++ Makefile - prevent overriding of CXXFLAGS and LDFLAGS

### DIFF
--- a/c++/Makefile
+++ b/c++/Makefile
@@ -15,8 +15,8 @@ endif
 COMMON_CXXFLAGS += -std=c++11 -Wall
 UNIX_CXXFLAGS := -I/usr/include
 
-CXXFLAGS := $(COMMON_CXXFLAGS) $(UNIX_CXXFLAGS)
-LDFLAGS := -pthread
+CXXFLAGS += $(COMMON_CXXFLAGS) $(UNIX_CXXFLAGS)
+LDFLAGS += -pthread
 
 # list of all targets
 targets = $(addprefix relaynetwork,client terminator proxy outbound)


### PR DESCRIPTION
- the changes to the respective flags should be made with append
  operation. This prevents breaking/removing any default flags
  supplied by an external build system (e.g. distribution specifici
  package build system)
