### PR TITLE
port to FreeBSD 10 & OSX 10.9.5

### DIFF
--- a/c++/Makefile
+++ b/c++/Makefile
@@ -7,15 +7,20 @@ MINGW_CXX = i686-w64-mingw32-g++
 
 COMMON_CXXFLAGS := -I.
 
+UNAME_S := $(shell uname -s)
+
 variant ?= production
 ifeq ($(variant),test)
   COMMON_CXXFLAGS += -DFOR_VALGRIND -g
 else
-  COMMON_CXXFLAGS += -DNDEBUG -O2 -flto
+  COMMON_CXXFLAGS += -DNDEBUG -O2
 endif
 
 platform ?= linux
-ifeq ($(platform),bsd)
+ifeq ($(UNAME_S),Linux)
+  COMMON_CXXFLAGS += -flto
+endif
+ifeq ($(UNAME_S),FreeBSD)
   COMMON_CXXFLAGS += -DX86_BSD
 endif
 

--- a/c++/Makefile
+++ b/c++/Makefile
@@ -20,6 +20,9 @@ platform ?= linux
 ifeq ($(UNAME_S),Linux)
   COMMON_CXXFLAGS += -flto
 endif
+ifeq ($(UNAME_S),Darwin)
+  COMMON_CXXFLAGS += -flto -DX86_BSD
+endif
 ifeq ($(UNAME_S),FreeBSD)
   COMMON_CXXFLAGS += -DX86_BSD
 endif

--- a/c++/Makefile
+++ b/c++/Makefile
@@ -1,6 +1,8 @@
 # all common objects that need to be build for all targets except for windows version
 common_objs := flaggedarrayset.o utils.o p2pclient.o ./crypto/sha2.o
 
+CXX=c++
+
 MINGW_CXX = i686-w64-mingw32-g++
 
 COMMON_CXXFLAGS := -I.

--- a/c++/client.cpp
+++ b/c++/client.cpp
@@ -6,11 +6,14 @@
 #include <assert.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdio.h>
 
 #ifdef WIN32
 	#include <winsock2.h>
 	#include <ws2tcpip.h>
 #else // WIN32
+	#include <sys/socket.h>
+	#include <netinet/in.h>
 	#include <netinet/tcp.h>
 	#include <netdb.h>
 	#include <fcntl.h>

--- a/c++/p2pclient.cpp
+++ b/c++/p2pclient.cpp
@@ -6,11 +6,14 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/time.h>
+#include <stdio.h>
 
 #ifdef WIN32
 	#include <winsock2.h>
 	#include <ws2tcpip.h>
 #else // WIN32
+	#include <sys/socket.h>
+	#include <netinet/in.h>
 	#include <netinet/tcp.h>
 	#include <netdb.h>
 	#include <fcntl.h>

--- a/c++/utils.h
+++ b/c++/utils.h
@@ -36,13 +36,11 @@
 	#define MSG_NOSIGNAL 0
 #elif (defined(__APPLE__) && defined(__MACH__))
 #include <sys/param.h>
-	#if defined(BSD)
 	uint16_t htole16 (uint16_t n);
 	uint32_t htole32 (uint32_t n);
 	uint64_t htole64 (uint64_t n);
 	uint32_t le32toh (uint32_t n);
-	#endif
-#elif defined(__BSD__)
+#elif defined(__FreeBSD__)
 	#include <sys/endian.h>
 #else
 	#include <endian.h>

--- a/c++/utils.h
+++ b/c++/utils.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include <assert.h>
+#include <unistd.h>
 
 /**********************************
  **** Things missing on !Linux ****
@@ -13,7 +14,7 @@
 	#define errno WSAGetLastError()
 #endif
 
-#if defined(WIN32) || defined(X86_BSD)
+#if defined(WIN32)
 	// Windows is LE-only anyway...
 	#ifdef htole16
 		#undef htole16
@@ -33,6 +34,16 @@
 	#define le16toh(val) (val)
 
 	#define MSG_NOSIGNAL 0
+#elif (defined(__APPLE__) && defined(__MACH__))
+#include <sys/param.h>
+	#if defined(BSD)
+	uint16_t htole16 (uint16_t n);
+	uint32_t htole32 (uint32_t n);
+	uint64_t htole64 (uint64_t n);
+	uint32_t le32toh (uint32_t n);
+	#endif
+#elif defined(__BSD__)
+	#include <sys/endian.h>
 #else
 	#include <endian.h>
 #endif


### PR DESCRIPTION
I have verified that this works on FreeBSD 10.  I left it running overnight with no issues.

On OS X I can build it, but it is failing with errno 65 'no route to host'? even though it actually works.
I can route around the issue by setting errno=0 just before the reconnect checks in the two clients.
I've done some instrumentation to try to discover which syscall is setting errno, but I've run out of time to work on this today.
