### PR TITLE
Add nameser_compat.h header for OSX builds.

### DIFF
--- a/c++/utils.cpp
+++ b/c++/utils.cpp
@@ -22,6 +22,10 @@
 	#include <resolv.h>
 #endif // !WIN32
 
+#ifdef __APPLE__
+	#include <arpa/nameser_compat.h>
+#endif
+
 /***************************
  **** Varint processing ****
  ***************************/


### PR DESCRIPTION
relayclient doesn't compile on OSX without this